### PR TITLE
Added support for SecurityToken…

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Initially, the EC2 and S3 API will be supported.
 type AWSEnv
     aws_id::String      # AWS Access Key id
     aws_seckey::String  # AWS Secret key for signing requests
+    aws_token::String   # AWS Security Token for temporary credentials
     ep_host::String     # region endpoint (host)
     ep_path::String     # region endpoint (path)
     timeout::Float64    # request timeout in seconds, if set to 0.0, request will never time out. Default is 0.0
@@ -31,10 +32,11 @@ end
 Constructors:
 
 ```
-AWSEnv(; id=AWS_ID, key=AWS_SECKEY, ep=EP_US_EAST_NORTHERN_VIRGINIA, timeout=0.0, dr=false, dbg=false)
+AWSEnv(; id=AWS_ID, key=AWS_SECKEY, token=AWS_TOKEN, ep=EP_US_EAST_NORTHERN_VIRGINIA, timeout=0.0, dr=false, dbg=false)
 ```
 
 - The ```AWS_ID``` and ```AWS_SECKEY``` are initialized from env if available. Else a file ~/.awssecret is read (if available) for the same.
+- The ```AWS_TOKEN``` is an empty string by default. Override ```token``` if the ```id``` and ```key``` are temporary security credentials.
 
 
 ### S3 API

--- a/src/AWS.jl
+++ b/src/AWS.jl
@@ -27,6 +27,7 @@ const US_WEST_2 = "us-west-2" # US West (Oregon) Region
 # Search for default AWS_ID and AWS_SECKEY
 AWS_ID = ""
 AWS_SECKEY = ""
+AWS_TOKEN = ""
 if haskey(ENV, "AWS_ID") && haskey(ENV, "AWS_SECKEY")
     AWS_ID = ENV["AWS_ID"]
     AWS_SECKEY = ENV["AWS_SECKEY"]
@@ -44,14 +45,15 @@ end
 type AWSEnv
     aws_id::String      # AWS Access Key id
     aws_seckey::String  # AWS Secret key for signing requests
+    aws_token::String   # AWS Security Token for temporary credentials
     ep_host::String     # region endpoint (host)
-    ep_path::String     # region eddpoint (path)
+    ep_path::String     # region endpoint (path)
     timeout::Float64    # request timeout in seconds, default is no timeout.
     dry_run::Bool       # If true, no actual request will be made - implies dbg flag below
     dbg::Bool           # print request to screen
 
 
-    function AWSEnv(; id=AWS_ID, key=AWS_SECKEY, ep=EP_US_EAST_NORTHERN_VIRGINIA, timeout=0.0, dr=false, dbg=false)
+    function AWSEnv(; id=AWS_ID, key=AWS_SECKEY, token=AWS_TOKEN, ep=EP_US_EAST_NORTHERN_VIRGINIA, timeout=0.0, dr=false, dbg=false)
         if (id == "") || (key == "")
             error("Invalid AWS security credentials provided")
         end
@@ -66,9 +68,9 @@ type AWSEnv
         end
 
         if dr
-            new(id, key, ep_host, ep_path, timeout, dr, true)
+            new(id, key, token, ep_host, ep_path, timeout, dr, true)
         else
-            new(id, key, ep_host, ep_path, timeout, false, dbg)
+            new(id, key, token, ep_host, ep_path, timeout, false, dbg)
         end
     end
 

--- a/src/EC2.jl
+++ b/src/EC2.jl
@@ -92,6 +92,9 @@ function ec2_execute(env::AWSEnv, action::String, params_in=nothing)
 #    push!(params, ("Expires", get_utc_timestamp(300))) # Request expires after 300 seconds
     push!(params, ("SignatureVersion", "2"))
     push!(params, ("SignatureMethod", "HmacSHA256"))
+    if env.aws_token != ""
+        push!(params, ("SecurityToken", env.aws_token))
+    end
 
 
     sorted = sort(params)

--- a/src/S3.jl
+++ b/src/S3.jl
@@ -680,6 +680,9 @@ end
 
 
 function canonicalize_and_sign(env::AWSEnv, ro::RO, md5::String)
+    if env.aws_token != ""
+        push!(ro.amz_hdrs, ("x-amz-security-token", env.aws_token))
+    end
     (new_amz_hdrs, amz_hdrs_str) = get_canon_amz_headers(ro.amz_hdrs)
     (full_path, sign_path) = get_canonicalized_resource(ro)
 


### PR DESCRIPTION
… which is used when AWS generates temporary security credentials (e.g., via IAM instance profile or STS).