### PR TITLE
add support for signature version 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ end
 Constructors:
 
 ```
-AWSEnv(; id=AWS_ID, key=AWS_SECKEY, token=AWS_TOKEN, ec2_creds=false, region=US_EAST_1, ep="", sig_ver=2, timeout=0.0, dr=false, dbg=false)
+AWSEnv(; id=AWS_ID, key=AWS_SECKEY, token=AWS_TOKEN, ec2_creds=false, region=US_EAST_1, ep="", sig_ver=4, timeout=0.0, dr=false, dbg=false)
 ```
 
 - The ```AWS_ID``` and ```AWS_SECKEY``` are initialized from env if available. Else a file ~/.awssecret is read (if available) for the same.

--- a/README.md
+++ b/README.md
@@ -1,32 +1,32 @@
 ## AWS - Julia interface to Amazon Web Services
 
-This package is a WIP for providing a native julia interface to the Amazon Web Services API
+This package is a WIP for providing a native Julia interface to the Amazon Web Services API
 
 Initially, the EC2 and S3 API will be supported.
 
 
 ### Current status
 - Most of the APIs are yet untested. Any testing will be helpful. The REST API does not not match exactly in certain cases
-  with the WSDL. For the EC2 API, the bulk of the code is generated from the WSDL while it has been translated by hand for the 
-  S3 API. In certain cases breakage may occur due to wrong request syntax. 
-  
-  Please file issues on guthub with the output from running the request in debug mode, i.e., with env.dbg = true.
-  
+  with the WSDL. For the EC2 API, the bulk of the code is generated from the WSDL while it has been translated by hand for the
+  S3 API. In certain cases breakage may occur due to wrong request syntax.
+
+  Please file issues on GitHub with the output from running the request in debug mode, i.e., with env.dbg = true.
+
 
 ### Usage
 - Each of the functions takes in an AWSEnv as the first parameter
 
 ```
 type AWSEnv
-    aws_id::String      # AWS Access Key id
-    aws_seckey::String  # AWS Secret key for signing requests
-    aws_token::String   # AWS Security Token for temporary credentials
-    ep_host::String     # region endpoint (host)
-    ep_path::String     # region endpoint (path)
-    timeout::Float64    # request timeout in seconds, if set to 0.0, request will never time out. Default is 0.0
-    dry_run::Bool       # If true, no actual request will be made - implies dbg flag below
-    dbg::Bool           # print request and raw response to screen
-    
+    aws_id::ASCIIString         # AWS Access Key id
+    aws_seckey::ASCIIString     # AWS Secret key for signing requests
+    aws_token::ASCIIString      # AWS Security Token for temporary credentials
+    ep_host::AbstractString     # region endpoint (host)
+    ep_path::AbstractString     # region endpoint (path)
+    timeout::Float64            # request timeout in seconds, if set to 0.0, request will never time out. Default is 0.0
+    dry_run::Bool               # If true, no actual request will be made - implies dbg flag below
+    dbg::Bool                   # print request and raw response to screen
+
 end
 ```
 Constructors:
@@ -43,9 +43,9 @@ AWSEnv(; id=AWS_ID, key=AWS_SECKEY, token=AWS_TOKEN, ec2_creds=false, ep=EP_US_E
 ### S3 API
 - This package uses the REST interface of S3
 
-- The type names, function names, etc follow the names specified in http://docs.aws.amazon.com/AmazonS3/latest/API/APIRest.html as well 
-  as in http://s3.amazonaws.com/doc/2006-03-01/AmazonS3.wsdl‎ 
-  
+- The type names, function names, etc follow the names specified in http://docs.aws.amazon.com/AmazonS3/latest/API/APIRest.html as well
+  as in http://s3.amazonaws.com/doc/2006-03-01/AmazonS3.wsdl
+
 - Sample code
 
 ```
@@ -90,7 +90,7 @@ println("$(resp.http_code), $(resp.obj)")
 
 
 println("Delete file 1")
-resp = S3.del_object(env, bkt, "file1") 
+resp = S3.del_object(env, bkt, "file1")
 println("$(resp.http_code), $(resp.obj)")
 
 println("Delete file 2 using the multi api")
@@ -115,18 +115,18 @@ type S3Response
     eTag::String
     http_code::Int
 
-    # Common amz fields 
-    delete_marker::Bool     
-    id_2::String        
+    # Common amz fields
+    delete_marker::Bool
+    id_2::String
     request_id::String
     version_id::String
 
     headers::Dict           # All header fields
-    
+
     obj::Any                # If the response was an XML representing a Julia S3 response type,
                             # it is parsed and set here.
                             # Else it will contain an IOBuffer object
-                            
+
     pd::Union(ETree, Nothing)
 end
 ```
@@ -140,7 +140,7 @@ EC2 has two sets of APIs
 
 - The other is a simple API that provides limited functionality but with a a higher abstraction.
 
-### EC2 Simple API 
+### EC2 Simple API
 
 - Currently the following are available:
 
@@ -154,17 +154,17 @@ EC2 has two sets of APIs
 - ec2_addprocs
 
 These are described [here](doc/ec2_simple.md)
-The source is in ```src/ec2_simple.jl``` 
+The source is in ```src/ec2_simple.jl```
 
 A generic API is ```ec2_basic```
 
-```ec2_basic(env::AWSEnv, action::String, params_in::Dict{Any, Any})``` just bundles the 
-supplied params_in into an EC2 request. It is meant to be used while bugs, if any, in the 
+```ec2_basic(env::AWSEnv, action::String, params_in::Dict{Any, Any})``` just bundles the
+supplied params_in into an EC2 request. It is meant to be used while bugs, if any, in the
 advanced (generated) code exist for any of the APIs. Values in the params can be basic julia types,
-CalendarTime, Dict or an Array itself. Keys in the Dict MUST be same as those mentioned in 
+CalendarTime, Dict or an Array itself. Keys in the Dict MUST be same as those mentioned in
 the Amazon EC2 documentation for the corresponding action.
 
-### EC2 Advanced API 
+### EC2 Advanced API
 
 
 Much of the boilerplate code is generated from the corresponding WSDL.
@@ -176,12 +176,12 @@ Types are defined in ```ec2_types.jl```
 
 Names and usage are similar to the AWS documentation http://awsdocs.s3.amazonaws.com/EC2/latest/ec2-api.pdf
 
-Each of the EC2 "actions" have a corresponding Julia function which takes in 
+Each of the EC2 "actions" have a corresponding Julia function which takes in
 the appropriate Julia type.
 
-For example : ```RunInstances(env::AWSEnv , msg::RunInstancesType)``` (defined in ec2_operations.jl) where 
+For example : ```RunInstances(env::AWSEnv , msg::RunInstancesType)``` (defined in ec2_operations.jl) where
 
-RunInstancesType (defined in ec2_types.jl) is 
+RunInstancesType (defined in ec2_types.jl) is
 
 ```
 type RunInstancesType
@@ -189,8 +189,8 @@ type RunInstancesType
     minCount::Union(Int32, Nothing)
     maxCount::Union(Int32, Nothing)
     ...
-    
-    RunInstancesType(; imageId=nothing, minCount=nothing, maxCount=nothing, keyName=nothing, groupSet=nothing, additionalInfo=nothing, userData=nothing, addressingType=nothing, instanceType=nothing, placement=nothing, kernelId=nothing, ramdiskId=nothing, blockDeviceMapping=nothing, monitoring=nothing, subnetId=nothing, disableApiTermination=nothing, instanceInitiatedShutdownBehavior=nothing, license=nothing, privateIpAddress=nothing, clientToken=nothing, networkInterfaceSet=nothing, iamInstanceProfile=nothing, ebsOptimized=nothing) = 
+
+    RunInstancesType(; imageId=nothing, minCount=nothing, maxCount=nothing, keyName=nothing, groupSet=nothing, additionalInfo=nothing, userData=nothing, addressingType=nothing, instanceType=nothing, placement=nothing, kernelId=nothing, ramdiskId=nothing, blockDeviceMapping=nothing, monitoring=nothing, subnetId=nothing, disableApiTermination=nothing, instanceInitiatedShutdownBehavior=nothing, license=nothing, privateIpAddress=nothing, clientToken=nothing, networkInterfaceSet=nothing, iamInstanceProfile=nothing, ebsOptimized=nothing) =
          new(imageId, minCount, maxCount, keyName, groupSet, additionalInfo, userData, addressingType, instanceType, placement, kernelId, ramdiskId, blockDeviceMapping, monitoring, subnetId, disableApiTermination, instanceInitiatedShutdownBehavior, license, privateIpAddress, clientToken, networkInterfaceSet, iamInstanceProfile, ebsOptimized)
 end
 ```
@@ -225,7 +225,7 @@ end
 
 For succcessful requests, EC2Response.obj will contain an object of the appropriate type.
 
-For example, for RunInstances, the EC2Response.obj will be of type RunInstancesResponseType 
+For example, for RunInstances, the EC2Response.obj will be of type RunInstancesResponseType
 
 
 
@@ -248,6 +248,5 @@ libexpat must be installed
 ### NOTE
 
 - The crypto functions required for this package are in https://github.com/amitmurthy/AWS.jl/blob/master/src/crypto.jl, since
-  OpenSSL.jl does not yet support the functions this package needs. This will be replaced with calls to OpenSSL.jl when 
+  OpenSSL.jl does not yet support the functions this package needs. This will be replaced with calls to OpenSSL.jl when
   it supports the same.
-

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ type AWSEnv
     aws_id::ASCIIString         # AWS Access Key id
     aws_seckey::ASCIIString     # AWS Secret key for signing requests
     aws_token::ASCIIString      # AWS Security Token for temporary credentials
+    region::AbstractString      # region name
     ep_host::AbstractString     # region endpoint (host)
     ep_path::AbstractString     # region endpoint (path)
     timeout::Float64            # request timeout in seconds, if set to 0.0, request will never time out. Default is 0.0
@@ -32,12 +33,14 @@ end
 Constructors:
 
 ```
-AWSEnv(; id=AWS_ID, key=AWS_SECKEY, token=AWS_TOKEN, ec2_creds=false, ep=EP_US_EAST_NORTHERN_VIRGINIA, timeout=0.0, dr=false, dbg=false)
+AWSEnv(; id=AWS_ID, key=AWS_SECKEY, token=AWS_TOKEN, ec2_creds=false, region=US_EAST_1, ep="", timeout=0.0, dr=false, dbg=false)
 ```
 
 - The ```AWS_ID``` and ```AWS_SECKEY``` are initialized from env if available. Else a file ~/.awssecret is read (if available) for the same.
 - The ```AWS_TOKEN``` is an empty string by default. Override ```token``` if the ```id``` and ```key``` are temporary security credentials.
 - Set ```ec2_creds``` to true to automatically retrieve temporary security credentials if running on an EC2 instance that has such credentials.
+- Set ```region``` to one of the AWS region name strings, e.g., "us-east-1". Not needed if setting ```ep```.
+- ```ep``` can contain both a hostname and a pathname for an AWS endpoint. It is generally not needed when using native AWS services; use ```region``` instead. If using a service that emulates AWS, set ```ep``` to the hostname of the endpoint to be used. If both ```region``` and ```ep``` are set, the host portion of ```ep``` will override region, and the path portion of ```ep``` will be used in conjunction with ```region```.
 
 
 ### S3 API

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ type AWSEnv
     region::AbstractString      # region name
     ep_host::AbstractString     # region endpoint (host)
     ep_path::AbstractString     # region endpoint (path)
+    sig_ver::Int                # AWS signature version (2 or 4)
     timeout::Float64            # request timeout in seconds, if set to 0.0, request will never time out. Default is 0.0
     dry_run::Bool               # If true, no actual request will be made - implies dbg flag below
     dbg::Bool                   # print request and raw response to screen
@@ -33,7 +34,7 @@ end
 Constructors:
 
 ```
-AWSEnv(; id=AWS_ID, key=AWS_SECKEY, token=AWS_TOKEN, ec2_creds=false, region=US_EAST_1, ep="", timeout=0.0, dr=false, dbg=false)
+AWSEnv(; id=AWS_ID, key=AWS_SECKEY, token=AWS_TOKEN, ec2_creds=false, region=US_EAST_1, ep="", sig_ver=2, timeout=0.0, dr=false, dbg=false)
 ```
 
 - The ```AWS_ID``` and ```AWS_SECKEY``` are initialized from env if available. Else a file ~/.awssecret is read (if available) for the same.
@@ -41,6 +42,7 @@ AWSEnv(; id=AWS_ID, key=AWS_SECKEY, token=AWS_TOKEN, ec2_creds=false, region=US_
 - Set ```ec2_creds``` to true to automatically retrieve temporary security credentials if running on an EC2 instance that has such credentials.
 - Set ```region``` to one of the AWS region name strings, e.g., "us-east-1". Not needed if setting ```ep```.
 - ```ep``` can contain both a hostname and a pathname for an AWS endpoint. It is generally not needed when using native AWS services; use ```region``` instead. If using a service that emulates AWS, set ```ep``` to the hostname of the endpoint to be used. If both ```region``` and ```ep``` are set, the host portion of ```ep``` will override region, and the path portion of ```ep``` will be used in conjunction with ```region```.
+- ```sig_ver``` must be set to 2 or 4. Some AWS services require one signature version or the other, in which case this value will be ignored.
 
 
 ### S3 API

--- a/src/AWS.jl
+++ b/src/AWS.jl
@@ -45,9 +45,9 @@ else
 end
 
 type AWSEnv
-    aws_id::AbstractString      # AWS Access Key id
-    aws_seckey::AbstractString  # AWS Secret key for signing requests
-    aws_token::AbstractString   # AWS Security Token for temporary credentials
+    aws_id::ASCIIString         # AWS Access Key id
+    aws_seckey::ASCIIString     # AWS Secret key for signing requests
+    aws_token::ASCIIString      # AWS Security Token for temporary credentials
     ep_host::AbstractString     # region endpoint (host)
     ep_path::AbstractString     # region endpoint (path)
     timeout::Float64    # request timeout in seconds, default is no timeout.

--- a/src/AWS.jl
+++ b/src/AWS.jl
@@ -57,7 +57,7 @@ type AWSEnv
     dbg::Bool                   # print request to screen
 
 
-    function AWSEnv(; id=AWS_ID, key=AWS_SECKEY, token=AWS_TOKEN, ec2_creds=false, region=US_EAST_1, ep="", sig_ver=2, timeout=0.0, dr=false, dbg=false)
+    function AWSEnv(; id=AWS_ID, key=AWS_SECKEY, token=AWS_TOKEN, ec2_creds=false, region=US_EAST_1, ep="", sig_ver=4, timeout=0.0, dr=false, dbg=false)
         if ec2_creds
             creds = get_instance_credentials()
             if creds != nothing
@@ -107,6 +107,9 @@ type AWSEnv
 
 end
 export AWSEnv
+
+ep_host(env::AWSEnv, service) = lowercase(env.ep_host=="" ? "$service.$(env.region).amazonaws.com" : env.ep_host)
+export ep_host
 
 function get_instance_credentials()
     try

--- a/src/AWS.jl
+++ b/src/AWS.jl
@@ -51,12 +51,13 @@ type AWSEnv
     region::AbstractString      # region name
     ep_host::AbstractString     # region endpoint (host)
     ep_path::AbstractString     # region endpoint (path)
+    sig_ver::Int                # AWS signature version (2 or 4)
     timeout::Float64            # request timeout in seconds, default is no timeout.
     dry_run::Bool               # If true, no actual request will be made - implies dbg flag below
     dbg::Bool                   # print request to screen
 
 
-    function AWSEnv(; id=AWS_ID, key=AWS_SECKEY, token=AWS_TOKEN, ec2_creds=false, region=US_EAST_1, ep="", timeout=0.0, dr=false, dbg=false)
+    function AWSEnv(; id=AWS_ID, key=AWS_SECKEY, token=AWS_TOKEN, ec2_creds=false, region=US_EAST_1, ep="", sig_ver=2, timeout=0.0, dr=false, dbg=false)
         if ec2_creds
             creds = get_instance_credentials()
             if creds != nothing
@@ -93,10 +94,14 @@ type AWSEnv
             error("No region or endpoint provided")
         end
 
+        if sig_ver != 2 && sig_ver != 4
+          error("Invalid signature version number")
+        end
+
         if dr
-            new(id, key, token, region, ep_host, ep_path, timeout, dr, true)
+            new(id, key, token, region, ep_host, ep_path, sig_ver, timeout, dr, true)
         else
-            new(id, key, token, region, ep_host, ep_path, timeout, false, dbg)
+            new(id, key, token, region, ep_host, ep_path, sig_ver, timeout, false, dbg)
         end
     end
 
@@ -135,6 +140,7 @@ end
 
 include("aws_utils.jl")
 include("crypto.jl")
+include("sign.jl")
 include("EC2.jl")
 include("S3.jl")
 

--- a/src/EC2.jl
+++ b/src/EC2.jl
@@ -53,31 +53,6 @@ end
 export EC2Response
 
 
-
-
-function aws_string(dt::DateTime)
-    y,m,d = Dates.yearmonthday(dt)
-    h,mi,s = Dates.hour(dt),Dates.minute(dt),Dates.second(dt)
-    yy = y < 0 ? @sprintf("%05i",y) : lpad(y,4,"0")
-    mm = lpad(m,2,"0")
-    dd = lpad(d,2,"0")
-    hh = lpad(h,2,"0")
-    mii = lpad(mi,2,"0")
-    ss = lpad(s,2,"0")
-    return "$yy-$mm-$(dd)T$hh:$mii:$ss"
-end
-
-aws_string(v::Bool) = v ? "True" : "False"
-aws_string(v::Any) = string(v)
-
-
-#ISO8601
-function get_utc_timestamp(addsecs=0)
-    dt = Dates.unix2datetime(Dates.datetime2unix(now(Dates.UTC)) + addsecs)
-    return string(aws_string(dt), "Z")
-end
-
-
 function ec2_execute(env::AWSEnv, action::AbstractString, params_in=nothing)
     # Prepare the standard params
     params=Array(Tuple,0)
@@ -90,39 +65,19 @@ function ec2_execute(env::AWSEnv, action::AbstractString, params_in=nothing)
     push!(params, ("Timestamp", get_utc_timestamp()))
     push!(params, ("Version", "2015-04-15"))
 #    push!(params, ("Expires", get_utc_timestamp(300))) # Request expires after 300 seconds
-    push!(params, ("SignatureVersion", "2"))
-    push!(params, ("SignatureMethod", "HmacSHA256"))
     if env.aws_token != ""
         push!(params, ("SecurityToken", env.aws_token))
     end
 
-
-    sorted = sort(params)
-    querystr = HTTPC.urlencode_query_params(sorted)
+    signed_querystr = canonicalize_and_sign!(params, env, "ec2", "GET")
 
     ep_host = env.ep_host=="" ? "ec2.$(env.region).amazonaws.com" : env.ep_host
-
-    str2sign = "GET\n" * lowercase(ep_host) * "\n" * env.ep_path * "\n" * querystr
-    sb = Crypto.hmacsha256_digest(str2sign, env.aws_seckey)
-
-    signature_b64 = base64encode(sb)
-
-    #escape the signature
-    signature_querystr = HTTPC.urlencode_query_params([("Signature", bytestring(signature_b64))])
-
-    complete_url = "http://" * ep_host * env.ep_path * (env.ep_path[end] == '/' ? "" : "/") * "?" * querystr * "&" * signature_querystr
-
-    #make the request
+    complete_url = "http://" * ep_host * env.ep_path * (env.ep_path[end] == '/' ? "" : "/") * "?" * signed_querystr
     if (env.dbg) || (env.dry_run)
-        for (k, v) in sorted
-            println("$k => $v")
-        end
-        println("String to sign => " * str2sign)
-        println("Signature => " * bytestring(signature_b64) * "\n")
-
-        println("URL:\n$complete_url \n")
+        println("URL:\n$complete_url\n")
     end
 
+    #make the request
     ec2resp = EC2Response()
     if !(env.dry_run)
         ro = HTTPC.RequestOptions(request_timeout = env.timeout)

--- a/src/aws_utils.jl
+++ b/src/aws_utils.jl
@@ -101,8 +101,12 @@ export aws_string
 
 
 #ISO8601
-function get_utc_timestamp(addsecs=0)
+function get_utc_timestamp(addsecs=0;basic=false)
     dt = Dates.unix2datetime(Dates.datetime2unix(now(Dates.UTC)) + addsecs)
-    return string(aws_string(dt), "Z")
+    dstr = aws_string(dt)
+    if basic
+        dstr = replace(dstr, Set(":-"), "")
+    end
+    return string(dstr, "Z")
 end
 export get_utc_timestamp

--- a/src/aws_utils.jl
+++ b/src/aws_utils.jl
@@ -82,3 +82,27 @@ function xml(tag::AbstractString, children::Array; xmlns="", xsi_type="")
     return open_tag * children_xml * "</$(tag)>"
 end
 
+
+function aws_string(dt::DateTime)
+    y,m,d = Dates.yearmonthday(dt)
+    h,mi,s = Dates.hour(dt),Dates.minute(dt),Dates.second(dt)
+    yy = y < 0 ? @sprintf("%05i",y) : lpad(y,4,"0")
+    mm = lpad(m,2,"0")
+    dd = lpad(d,2,"0")
+    hh = lpad(h,2,"0")
+    mii = lpad(mi,2,"0")
+    ss = lpad(s,2,"0")
+    return "$yy-$mm-$(dd)T$hh:$mii:$ss"
+end
+
+aws_string(v::Bool) = v ? "True" : "False"
+aws_string(v::Any) = string(v)
+export aws_string
+
+
+#ISO8601
+function get_utc_timestamp(addsecs=0)
+    dt = Dates.unix2datetime(Dates.datetime2unix(now(Dates.UTC)) + addsecs)
+    return string(aws_string(dt), "Z")
+end
+export get_utc_timestamp

--- a/src/crypto.jl
+++ b/src/crypto.jl
@@ -25,6 +25,7 @@ typealias size_t Csize_t
 
 @c Ptr{UInt8} HMAC (Ptr{EVP_MD}, Ptr{Void}, Int32, Ptr{UInt8}, size_t, Ptr{UInt8}, Ptr{UInt32}) libcrypto
 @c Ptr{UInt8} MD5 (Ptr{UInt8}, size_t, Ptr{UInt8}) libcrypto
+@c Ptr{UInt8} SHA256 (Ptr{UInt8}, size_t, Ptr{UInt8}) libcrypto
 
 @c Ptr{EVP_MD} EVP_md5 () libcrypto
 @c Ptr{EVP_MD} EVP_sha1 () libcrypto
@@ -110,7 +111,11 @@ function md5(s::IO)
 end
 export md5
 
+function sha256(s::AbstractString)
+    sha = zeros(UInt8, 32)
+    assert(SHA256(s, length(s), sha) != C_NULL)
+    return sha
+end
+
 
 end # Module end
-
-

--- a/src/sign.jl
+++ b/src/sign.jl
@@ -1,0 +1,36 @@
+function canonicalize_and_sign!(params, env::AWSEnv, service::ASCIIString, method::ASCIIString="GET")
+    if env.sig_ver == 2
+      signature_version_2!(params, env, service, method)
+    elseif env.sig_ver == 4
+      error("signature version 4 not yet implemented")
+    else
+      error("invalid signature version $(env.sig_ver)")
+    end
+end
+export canonicalize_and_sign!
+
+function signature_version_2!(params, env::AWSEnv, service::ASCIIString, method)
+    push!(params, ("SignatureVersion", "2"))
+    push!(params, ("SignatureMethod", "HmacSHA256"))
+
+    sort!(params)
+    querystr = HTTPC.urlencode_query_params(params)
+
+    ep_host = env.ep_host=="" ? "$service.$(env.region).amazonaws.com" : env.ep_host
+
+    str2sign = "$method\n" * lowercase(ep_host) * "\n" * env.ep_path * "\n" * querystr
+    sb = Crypto.hmacsha256_digest(str2sign, env.aws_seckey)
+
+    signature_b64 = bytestring(base64encode(sb))
+
+    push!(params, ("Signature", signature_b64))
+
+    if (env.dbg) || (env.dry_run)
+        for (k, v) in params
+            println("$k => $v")
+        end
+        println("--------\nString to sign:\n" * str2sign * "\n--------")
+    end
+
+    return HTTPC.urlencode_query_params(params)
+end

--- a/src/sign.jl
+++ b/src/sign.jl
@@ -1,36 +1,98 @@
-function canonicalize_and_sign!(params, env::AWSEnv, service::ASCIIString, method::ASCIIString="GET")
+function canonicalize_and_sign(env::AWSEnv, service, method, params)
     if env.sig_ver == 2
-      signature_version_2!(params, env, service, method)
+      signature_version_2(env, service, method, copy(params))
     elseif env.sig_ver == 4
-      error("signature version 4 not yet implemented")
+      signature_version_4(env, service, method, copy(params))
     else
       error("invalid signature version $(env.sig_ver)")
     end
 end
-export canonicalize_and_sign!
+export canonicalize_and_sign
 
-function signature_version_2!(params, env::AWSEnv, service::ASCIIString, method)
-    push!(params, ("SignatureVersion", "2"))
-    push!(params, ("SignatureMethod", "HmacSHA256"))
+function signature_version_2(env::AWSEnv, service, method, request_parameters)
+    if env.aws_token != ""
+        push!(request_parameters, ("SecurityToken", env.aws_token))
+    end
+    push!(request_parameters, ("SignatureVersion", "2"))
+    push!(request_parameters, ("SignatureMethod", "HmacSHA256"))
+    sort!(request_parameters)
 
-    sort!(params)
-    querystr = HTTPC.urlencode_query_params(params)
+    canonical_querystring = HTTPC.urlencode_query_params(request_parameters)
 
-    ep_host = env.ep_host=="" ? "$service.$(env.region).amazonaws.com" : env.ep_host
+    string_to_sign = method * "\n" * ep_host(env, service) * "\n" * env.ep_path * "\n" * canonical_querystring
 
-    str2sign = "$method\n" * lowercase(ep_host) * "\n" * env.ep_path * "\n" * querystr
-    sb = Crypto.hmacsha256_digest(str2sign, env.aws_seckey)
+    signature = bytestring(base64encode(sign(env.aws_seckey, string_to_sign)))
 
-    signature_b64 = bytestring(base64encode(sb))
-
-    push!(params, ("Signature", signature_b64))
+    push!(request_parameters, ("Signature", signature))
 
     if (env.dbg) || (env.dry_run)
-        for (k, v) in params
-            println("$k => $v")
+        println("Parameters:")
+        for (k, v) in request_parameters
+            println("  $k => $v")
         end
-        println("--------\nString to sign:\n" * str2sign * "\n--------")
+        println("--------\nString to sign:\n" * string_to_sign * "\n--------")
     end
 
-    return HTTPC.urlencode_query_params(params)
+    return (Tuple[], HTTPC.urlencode_query_params(request_parameters))
 end
+
+function signature_version_4(env::AWSEnv, service, method, request_parameters)
+    # inputs to request
+    sort!(request_parameters)
+    amzdate = get_utc_timestamp(; basic=true)
+    datestamp = amzdate[1:searchindex(amzdate, "T")-1]
+    payload = "" ##### Assume empty payload for the moment.
+
+    # Task 1: canonical request
+    canonical_uri = env.ep_path
+    canonical_querystring = HTTPC.urlencode_query_params(request_parameters)
+    canonical_headers = "host:" * ep_host(env, service) * "\n" * "x-amz-date:" * amzdate * "\n"
+    signed_headers = "host;x-amz-date"
+    payload_hash = bytes2hex(Crypto.sha256(payload))
+    canonical_request = method * "\n" * canonical_uri * "\n" * canonical_querystring * "\n" *
+        canonical_headers * "\n" * signed_headers * "\n" * payload_hash
+
+    # Task 2: string to sign
+    algorithm = "AWS4-HMAC-SHA256"
+    credential_scope = datestamp * "/" * env.region * "/" * service * "/" * "aws4_request"
+    string_to_sign = algorithm * "\n" * amzdate * "\n" * credential_scope * "\n" * bytes2hex(Crypto.sha256(canonical_request))
+
+    # Task 3: calculate the signature
+    signing_key = get_signature_key(env.aws_seckey, datestamp, env.region, service)
+    signature = bytes2hex(sign(signing_key, string_to_sign))
+
+    # Task 4: add signing information to request ##### how to return header to caller?
+    authorization_header = algorithm * " " * "Credential=" * env.aws_id * "/" * credential_scope * ", " *
+        "SignedHeaders=" * signed_headers * ", " * "Signature=" * signature
+    headers = [("Authorization", authorization_header),
+              ("X-Amz-Date", amzdate)]
+    if env.aws_token != ""
+        push!(headers, ("X-Amz-Security-Token", env.aws_token))
+    end
+
+    if (env.dbg) || (env.dry_run)
+        println("Parameters:")
+        for (k, v) in request_parameters
+            println("  $k => $v")
+        end
+        println("--------\nCanonical request:\n" * canonical_request)
+        println("--------\nString to sign:\n" * string_to_sign * "\n--------")
+        println("Headers:")
+        println("  Host: " * ep_host(env, service))
+        for (k, v) in headers
+            println("  $k: $v")
+        end
+    end
+
+    return (headers, HTTPC.urlencode_query_params(request_parameters))
+end
+
+function get_signature_key(key, datestamp, region, service)
+    kDate = sign("AWS4" * key, datestamp)
+    kRegion = sign(kDate, region)
+    kService = sign(kRegion, service)
+    kSigning = sign(kService, "aws4_request")
+    return kSigning
+end
+
+sign(key, msg) = Crypto.hmacsha256_digest(msg, key)


### PR DESCRIPTION
In preparation for the addition of AWS services that require signature version4, implement code for performing this signing method.  Connect the EC2 code to this signing method.

This PR also utilizes https for connecting to the EC2 service rather than http.

Note: because some lines are changed in common, this PR is based on PR #48 (which in turn is based on #47).  Please merge #47 and then #48 before merging this one. Let me know if you'd like me to squash or rebase after each individual merge.